### PR TITLE
Including BCC github repository

### DIFF
--- a/chapter2/README.md
+++ b/chapter2/README.md
@@ -1,6 +1,6 @@
 # Chapter 2
 
-You'll need BCC installed for the examples in this directory.
+You'll need [BCC](https://github.com/iovisor/bcc) installed for the examples in this directory.
 
 * `hello.py` - simple example that emits trace messages triggered by a kprobe
 * `hello-map.py` - introduce the concept of a BPF map


### PR DESCRIPTION
In order to help others to find the repository, I suggest to include the github repository.

I faced an issue with warnings when I tried to install the BCC and I could find the solution by installing the BCC through the source code (https://github.com/iovisor/bcc/issues/3366) . I don't know if it could be useful to include this information here somewhere.