### PR TITLE
Fix chapter3/ SEC('raw_tp')

### DIFF
--- a/chapter3/hello-func.bpf.c
+++ b/chapter3/hello-func.bpf.c
@@ -5,7 +5,7 @@ static __attribute((noinline)) int get_opcode(struct bpf_raw_tracepoint_args *ct
     return ctx->args[1];
 }
 
-SEC("raw_tp")
+SEC("raw_tp/")
 int hello(struct bpf_raw_tracepoint_args *ctx) {
     int opcode = get_opcode(ctx);
     bpf_printk("Syscall: %d", opcode);


### PR DESCRIPTION
## Description:

With this PR, I'm changing the **hello-func.bpf.c** instruction `SEC("raw_tp")` to `SEC("raw_tp/")`.

Must close https://github.com/lizrice/learning-ebpf/issues/25.