### PR TITLE
Modify lima config file to install version-specific linux-tools package for VM OS kernel

### DIFF
--- a/learning-ebpf.yaml
+++ b/learning-ebpf.yaml
@@ -19,5 +19,6 @@ provision:
     apt-get update
     apt-get install -y apt-transport-https ca-certificates curl clang llvm jq
     apt-get install -y libelf-dev libpcap-dev libbfd-dev binutils-dev build-essential make 
-    apt-get install -y linux-tools-common linux-tools-$(uname -r) bpfcc-tools
+    apt-get install -y linux-tools-common linux-tools-$(uname -r) 
+    apt-get install -y bpfcc-tools
     apt-get install -y python3-pip

--- a/learning-ebpf.yaml
+++ b/learning-ebpf.yaml
@@ -19,5 +19,5 @@ provision:
     apt-get update
     apt-get install -y apt-transport-https ca-certificates curl clang llvm jq
     apt-get install -y libelf-dev libpcap-dev libbfd-dev binutils-dev build-essential make 
-    apt-get install -y linux-tools-common linux-tools-5.15.0-41-generic bpfcc-tools
+    apt-get install -y linux-tools-common linux-tools-$(uname -r) bpfcc-tools
     apt-get install -y python3-pip


### PR DESCRIPTION
This MR updates the lima install script to automatically download the correct linux-tools package according to the kernel version of the VM OS image. This change fixes the silent failure in the installation of `linux-tools-5.15.0-41-generic` and `bpfcc-tools`, which led to errors in running the examples.

During my installation (Apple Silicon), the script downloaded the ARM VM image

```
$ limactl start learning-ebpf.yaml

Creating an instance "learning-ebpf" Proceed with the current configuration
INFO[0001] Attempting to download the image arch=aarch64 digest= location="https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img"
```

The kernel version for this image is 5.15.0-75-generic

```
root@lima-learning-ebpf:/Users/tks/Projects/learning-ebpf# uname -r 
5.15.0-75-generic 
```

When the lima VM starts, it runs a script which installs the following packages

```
apt-get install -y linux-tools-common linux-tools-5.15.0-41-generic bpfcc-tools
```

During this stage, installing `linux-tools-5.15.0-41-generic` fails silently, which then skips installing `bpfcc-tools`

```
apt-get install linux-tools-5.15.0-41-generic
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package linux-tools-5.15.0-41-generic
E: Couldn't find any package by glob 'linux-tools-5.15.0-41-generic'
E: Couldn't find any package by regex 'linux-tools-5.15.0-41-generic'
```

To run the chapter2 python example, I had to install `bpfcc-tools` manually, or else I get Python bcc errors
```
root@lima-learning-ebpf:/Users/tks/Projects/learning-ebpf/chapter2# python3 hello.py
Traceback (most recent call last):
  File "/Users/tks/Projects/learning-ebpf/chapter2/hello.py", line 2, in <module>
    from bcc import BPF
ModuleNotFoundError: No module named 'bcc'
```

After running `apt-install bpfcc-tools`, the Python example works correctly. 

To get the other examples to work correctly, I then had to install the linux-tools package for my kernel using `apt-get install linux-tools-$(uname -r)` 

After modifying the lima config file to download the correct linux-tools package, I was able to immediately run the Python examples upon starting a new lima VM.

Please let me know if anything else should be changed for this, or if I missed something during my initial install. Thanks! 