### PR TITLE
Update ping.bpf.c to match README

### DIFF
--- a/chapter8/README.md
+++ b/chapter8/README.md
@@ -12,7 +12,7 @@ this program and attaches it to the localhost interface.
 * In one terminal, start `ping`. You should see it showing a ping response being
   received every second, each one with an incrementing `icmp_seq`
   number
-* While `ping` is still running in the first termina, run `ping.py` in a second
+* While `ping` is still running in the first terminal, run `ping.py` in a second
   terminal. You will see trace showing that a ping packet is detected every
   second, but if you look in the first terminal you'll see that the responses
   are no longer being received. That's because the requests are being dropped by

--- a/chapter8/ping.bpf.c
+++ b/chapter8/ping.bpf.c
@@ -8,7 +8,7 @@ int xdp(struct xdp_md *ctx) {
 
   if (is_icmp_ping_request(data, data_end)) {
         bpf_trace_printk("Got ping packet");
-        return XDP_PASS;
+        return XDP_DROP;
   }
 
   return XDP_PASS;


### PR DESCRIPTION
Hi! I noticed that ping.bpf.c was always returning `XDP_PASS`, which didn't match the description in the README. I updated it to return `XDP_DROP` instead. Hope this small fix helps!