### PR TITLE
Add buffer space for null byte

### DIFF
--- a/chapter4/hello-buffer-config.py
+++ b/chapter4/hello-buffer-config.py
@@ -5,7 +5,7 @@ import ctypes as ct
 
 program = r"""
 struct user_msg_t {
-   char message[12];
+   char message[13];
 };
 
 BPF_HASH(config, u32, struct user_msg_t);


### PR DESCRIPTION
Without enough space to store the '\0' byte, the following is printed by `bpftool` on my system:

```bash
sudo bpftool map dump name config
[{
        "key": 501,
        "value": {
            "message": [72,105,32,117,115,101,114,32,53,48,49,33
            ]
        }
    },{
        "key": 0,
        "value": {
            "message": "Hey root!"
        }
    }
]
```

I do wonder if this should use `bpf_probe_read_kernel_str` instead of `bpf_probe_read_kernel` since the `ctypes.create_string_buffer` allocates this as a null terminated string. It makes no real difference to this working correctly, but may be "more correct". Let me know if you'd like me to add that to this PR.