### PR TITLE
Avoid cluttering console

### DIFF
--- a/chapter2/hello-tail.py
+++ b/chapter2/hello-tail.py
@@ -3,7 +3,7 @@ from bcc import BPF
 import ctypes as ct
 
 program = r"""
-BPF_PROG_ARRAY(syscall, 300);
+BPF_PROG_ARRAY(syscall, 500);
 
 int hello(struct bpf_raw_tracepoint_args *ctx) {
     int opcode = ctx->args[1];
@@ -46,36 +46,17 @@ exec_fn = b.load_func("hello_exec", BPF.RAW_TRACEPOINT)
 timer_fn = b.load_func("hello_timer", BPF.RAW_TRACEPOINT)
 
 prog_array = b.get_table("syscall")
+
+# Ignore all syscalls initially
+for i in range(len(prog_array)):
+    prog_array[ct.c_int(i)] = ct.c_int(ignore_fn.fd)
+
+# Only enable few syscalls which are of the interest
 prog_array[ct.c_int(59)] = ct.c_int(exec_fn.fd)
 prog_array[ct.c_int(222)] = ct.c_int(timer_fn.fd)
 prog_array[ct.c_int(223)] = ct.c_int(timer_fn.fd)
 prog_array[ct.c_int(224)] = ct.c_int(timer_fn.fd)
 prog_array[ct.c_int(225)] = ct.c_int(timer_fn.fd)
 prog_array[ct.c_int(226)] = ct.c_int(timer_fn.fd)
-
-# Ignore some syscalls that come up a lot
-prog_array[ct.c_int(21)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(22)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(25)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(29)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(56)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(57)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(63)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(64)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(66)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(72)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(73)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(79)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(98)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(101)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(115)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(131)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(134)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(135)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(139)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(172)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(233)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(280)] = ct.c_int(ignore_fn.fd)
-prog_array[ct.c_int(291)] = ct.c_int(ignore_fn.fd)
 
 b.trace_print()


### PR DESCRIPTION
As mentioned in the issue https://github.com/lizrice/learning-ebpf/issues/45, I updated the code.
Hope this helps.

Post this change, I see following output

```bash
sudo ./hello-tail.py
In file included from <built-in>:2:
In file included from /virtual/include/bcc/bpf.h:12:
In file included from include/linux/types.h:6:
In file included from include/uapi/linux/types.h:14:
In file included from include/uapi/linux/posix_types.h:5:
In file included from include/linux/stddef.h:5:
In file included from include/uapi/linux/stddef.h:5:
In file included from include/linux/compiler_types.h:80:
include/linux/compiler-clang.h:41:9: warning: '__HAVE_BUILTIN_BSWAP32__' macro redefined [-Wmacro-redefined]
#define __HAVE_BUILTIN_BSWAP32__
        ^
<command line>:4:9: note: previous definition is here
#define __HAVE_BUILTIN_BSWAP32__ 1
        ^
In file included from <built-in>:2:
In file included from /virtual/include/bcc/bpf.h:12:
In file included from include/linux/types.h:6:
In file included from include/uapi/linux/types.h:14:
In file included from include/uapi/linux/posix_types.h:5:
In file included from include/linux/stddef.h:5:
In file included from include/uapi/linux/stddef.h:5:
In file included from include/linux/compiler_types.h:80:
include/linux/compiler-clang.h:42:9: warning: '__HAVE_BUILTIN_BSWAP64__' macro redefined [-Wmacro-redefined]
#define __HAVE_BUILTIN_BSWAP64__
        ^
<command line>:5:9: note: previous definition is here
#define __HAVE_BUILTIN_BSWAP64__ 1
        ^
In file included from <built-in>:2:
In file included from /virtual/include/bcc/bpf.h:12:
In file included from include/linux/types.h:6:
In file included from include/uapi/linux/types.h:14:
In file included from include/uapi/linux/posix_types.h:5:
In file included from include/linux/stddef.h:5:
In file included from include/uapi/linux/stddef.h:5:
In file included from include/linux/compiler_types.h:80:
include/linux/compiler-clang.h:43:9: warning: '__HAVE_BUILTIN_BSWAP16__' macro redefined [-Wmacro-redefined]
#define __HAVE_BUILTIN_BSWAP16__
        ^
<command line>:3:9: note: previous definition is here
#define __HAVE_BUILTIN_BSWAP16__ 1
        ^
3 warnings generated.
b'   hello-tail.py-2499    [000] .....  6464.246546: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.246701: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.246911: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247366: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247378: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247384: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247389: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247393: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247398: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247403: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247407: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247412: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247417: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.247421: bpf_trace_printk: Another syscall: 321'
b'CPU:0 [LOST 102 EVENTS]'
b'   hello-tail.py-2499    [000] .....  6464.248184: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.248189: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.248189: bpf_trace_printk: Another syscall: 321'
b'   hello-tail.py-2499    [000] .....  6464.248189: bpf_trace_printk: Another syscall: 321'

# Repeated prints of above calls come but it stops in a while.
# If I do sudo ls in another terminal, I see following

b'            bash-2501    [001] .....  6471.837279: bpf_trace_printk: Executing a program'
b'           <...>-2503    [000] .....  6471.847721: bpf_trace_printk: Executing a program'
b'           <...>-2505    [000] .....  6471.854628: bpf_trace_printk: Executing a program'
b'            bash-2507    [001] .....  6471.856390: bpf_trace_printk: Executing a program'
b'           <...>-2506    [000] .....  6471.858664: bpf_trace_printk: Executing a program' 

```