### PR TITLE
Change Python shebang to #!/usr/bin/env python3

### DIFF
--- a/chapter2/hello-buffer.py
+++ b/chapter2/hello-buffer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3  
+#!/usr/bin/env python3
 from bcc import BPF
 
 program = r"""

--- a/chapter2/hello-file-ring-buffer.py
+++ b/chapter2/hello-file-ring-buffer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3  
+#!/usr/bin/env python3
 from bcc import BPF
 
 program = r"""

--- a/chapter2/hello-file.py
+++ b/chapter2/hello-file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3  
+#!/usr/bin/env python3
 from bcc import BPF
 
 program = r"""

--- a/chapter2/hello-map.py
+++ b/chapter2/hello-map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3  
+#!/usr/bin/env python3
 from bcc import BPF
 from time import sleep
 

--- a/chapter2/hello-tail.py
+++ b/chapter2/hello-tail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3  
+#!/usr/bin/env python3
 from bcc import BPF
 import ctypes as ct
 

--- a/chapter2/hello.py
+++ b/chapter2/hello.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3  
+#!/usr/bin/env python3
 from bcc import BPF
 import sys
 

--- a/chapter4/hello-buffer-config.py
+++ b/chapter4/hello-buffer-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3  
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from bcc import BPF
 import ctypes as ct

--- a/chapter4/hello-ring-buffer-config.py
+++ b/chapter4/hello-ring-buffer-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3  
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from bcc import BPF
 import ctypes as ct

--- a/chapter9/hello-lsm.py
+++ b/chapter9/hello-lsm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3  
+#!/usr/bin/env python3
 from bcc import BPF
 
 program = r"""


### PR DESCRIPTION
I notice that Python shebang has being changed from `#!/usr/bin/python` in the book(e.g. P15) to `#!/usr/bin/python3` in this repo.

But it's not enough as described in https://stackoverflow.com/questions/6908143/should-i-put-shebang-in-python-scripts-and-what-form-should-it-take